### PR TITLE
Add datum and script metadata to UTxO API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1015,6 +1015,7 @@ dependencies = [
  "cardano-mempool-sync",
  "clap",
  "cml-chain",
+ "cml-core",
  "cml-crypto",
  "derive_more 1.0.0",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,4 @@ rocksdb = "0.22.*"
 rmp-serde = "1.3.0"
 tempfile = "3.10.1"
 hex = "0.4.3"
+cml-core = { git = "https://github.com/oskin1/cardano-multiplatform-lib.git", rev = "13c35772222fc46b26177a62726720502bdf21e4" }


### PR DESCRIPTION
## Summary
- include datum hash, inline datum, and script reference in the UTxO API responses with hex encoding
- expose script metadata through a ScriptRefDto that classifies native and Plutus (V1/V2/V3) script references
- add the cml-core dependency to access serialization helpers for datum and script CBOR conversion

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68d5872a1eec832da33bba6c8aab911a