### PR TITLE
feat: filter unspent utxos by asset unit

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Query UTXOs for a specific public key hash.
 | `"Unspent"` | Get spendable UTXOs (most common) | `"Unspent"` |
 | `{"All": null}` | Get all UTXOs since service start | `{"All": null}` |
 | `{"All": 123456}` | Get all UTXOs from specific slot | `{"All": 123456}` |
+| `{"unspentByUnit": "<policy_id><asset_name>"}` | Get spendable UTXOs that contain a specific asset unit | `{"unspentByUnit": "<policy_id><asset_name>"}` |
 
 **Examples:**
 
@@ -89,6 +90,13 @@ Get spendable UTXOs:
 curl -X POST http://localhost:8080/getUtxos \
   -H "Content-Type: application/json" \
   -d '{"pkh": "your_pkh", "query": "Unspent", "offset": 0, "limit": 100}'
+```
+
+Get unspent UTXOs containing a specific unit:
+```bash
+curl -X POST http://localhost:8080/getUtxos \
+  -H "Content-Type: application/json" \
+  -d '{"pkh": "your_pkh", "query": {"unspentByUnit": "policyidassetname"}, "offset": 0, "limit": 100}'
 ```
 
 Get transaction history:
@@ -116,6 +124,11 @@ once and supply individual lookup parameters for each entry.
       "hash": "stake_test1...",
       "mode": "byStakingCredential",
       "query": {"All": null}
+    },
+    {
+      "address": "addr_test1...",
+      "mode": "byPaymentCredential",
+      "query": {"unspentByUnit": "policyidassetname"}
     }
   ],
   "offset": 0,

--- a/src/server.rs
+++ b/src/server.rs
@@ -286,9 +286,8 @@ where
             request.mode.clone(),
         ) {
             Ok((credential, kind)) => {
-                let utxos = db
-                    .get_utxos(credential, kind, request.query, offset, limit)
-                    .await;
+                let query = request.query.clone();
+                let utxos = db.get_utxos(credential, kind, query, offset, limit).await;
                 responses.push(GetTxOsBatchResponseItem {
                     request,
                     utxos: utxos.into_iter().map(UTxO::from).collect(),
@@ -409,8 +408,31 @@ mod tests {
         assert!(!json.is_empty());
         println!("{}", json);
 
+        let sample_lookup_unspent_by_unit = GetTxOsLookup {
+            address: Some("addr_test1qpz8h9w8sample000000000000000000000000000000000000".into()),
+            hash: None,
+            mode: AddressQueryMode::ByPaymentCredential,
+            query: TxoQuery::UnspentByUnit(
+                "policyid000000000000000000000000000000000000000000asset".into(),
+            ),
+        };
+
+        let sample_request_unspent_by_unit = GetTxOsRequest {
+            lookup: sample_lookup_unspent_by_unit.clone(),
+            offset: 0,
+            limit: 10,
+        };
+
+        let json = serde_json::to_string_pretty(&sample_request_unspent_by_unit).unwrap();
+        assert!(!json.is_empty());
+        println!("{}", json);
+
         let batch_request = GetTxOsBatchRequest {
-            requests: vec![sample_lookup_all.clone(), sample_lookup_unspent.clone()],
+            requests: vec![
+                sample_lookup_all.clone(),
+                sample_lookup_unspent.clone(),
+                sample_lookup_unspent_by_unit.clone(),
+            ],
             offset: 0,
             limit: 10,
         };


### PR DESCRIPTION
## Summary
- add a query variant that returns only unspent UTXOs holding a requested asset unit
- document the new request shape and extend sample payloads for individual and batch queries

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68d5dd05190c832db63e4107cb2eca6d